### PR TITLE
Refactor audio streaming

### DIFF
--- a/GlobalSuppressions.cs
+++ b/GlobalSuppressions.cs
@@ -2,7 +2,3 @@
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "<Pending>", Scope = "member", Target = "~M:bot7.VoiceCommands.CreateFileText(System.String,System.Int32)~System.Threading.Tasks.Task{System.String}")]


### PR DESCRIPTION
## Summary
- Add helper to resample any audio stream to Discord's 48kHz stereo format
- Use new resampling helper when sending audio to Discord to unify file and speech playback
- Skip resampling when the stream is already 48kHz stereo to keep song playback working
- Stream text-to-speech audio through the same resampling helper instead of writing to a temporary file

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_689d2c341b54832bb84e6289834323b2